### PR TITLE
gh workflow bump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
             ssh-add - <<< "${{secrets.DEPLOY_KEY}}"
             mkdir -p ~/.ssh/
             ssh-keyscan github.com >> ~/.ssh/known_hosts
-            ./avakas bump . auto --branch=mainline
+            avakas bump . auto --branch=mainline
             ssh-agent -k
   publish:
     if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
             ssh-add - <<< "${{secrets.DEPLOY_KEY}}"
             mkdir -p ~/.ssh/
             ssh-keyscan github.com >> ~/.ssh/known_hosts
+            make install
             avakas bump . auto --branch=mainline
             ssh-agent -k
   publish:


### PR DESCRIPTION
## Problem
Avakas is no longer a script within the directory but an installed binary

## Solution
Don't use relative path to invoke avakas for build