### PR TITLE
allow skipping dirty repo check and commiting changes

### DIFF
--- a/avakas/cli.py
+++ b/avakas/cli.py
@@ -88,7 +88,7 @@ def write_git(repo, directory, vsn_str, opt):
     ava = Avakas(directory=directory, opt=opt.__dict__)
     project = ava.flavor
 
-    if project.version_filename:
+    if project.version_filename and opt.commitchanges:
         repo.index.add([project.version_filename])
         skip_hooks = True
         if opt.with_hooks:
@@ -109,7 +109,7 @@ def load_git(directory, opt):
     if not repo:
         problems("Unable to find associated git repo for %s." % directory)
 
-    if repo.is_dirty():
+    if not opt.skipdirty and repo.is_dirty():
         problems("Git repo dirty.")
 
     if opt.branch not in repo.heads:
@@ -329,6 +329,16 @@ def parse_args(parser):
                       dest='filename',
                       help='File name. Used for fallback versioning.',
                       default='version')
+    parser.add_option('--skip-dirty',
+                      dest='skipdirty',
+                      help='Skip checking if local repo is dirty',
+                      action='store_true',
+                      default=False)
+    parser.add_option('--skip-commit-changes',
+                      dest='commitchanges',
+                      help='Skip commiting generated version files',
+                      action='store_false',
+                      default=True)
 
     if operation in ('set', 'bump'):
         parser.add_option('--with-hooks',

--- a/tests/integration/gates.bats
+++ b/tests/integration/gates.bats
@@ -23,3 +23,24 @@ teardown() {
     scan_lines "Problem: Git repo dirty." "${lines[@]}"
 }
 
+@test "skip checking for dirty files" {
+    cd "$REPO"
+    touch aaaa
+    git add aaaa
+    avakas_rc 0 set "$REPO" "0.0.2" --skip-dirty
+    scan_lines "Version set to 0.0.2" "${lines[@]}"
+}
+
+@test "version file is being tracked" {
+    cd "$REPO"
+    avakas_rc 0 set "$REPO" "0.0.3" --filename tracked_version
+    scan_lines "Version set to 0.0.3" "${lines[@]}"
+    test $(git ls-files --error-unmatch tracked_version)
+}
+
+@test "skip committing version file" {
+    cd "$REPO"
+    avakas_rc 0 set "$REPO" "0.0.4" --filename da_testfile --skip-commit-change
+    scan_lines "Version set to 0.0.4" "${lines[@]}"
+    test ! $(git ls-files --error-unmatch da_testfile)
+}


### PR DESCRIPTION
## Problem
For some build processes, ephemeral build files will be created within the repo requiring explicit cleanup before running avakas. Additionally, avakas is opinionated in ensuring that generated version files get checked back into mainline branch. Users should have the ability to skip this behavior and only allow tagging.

## Solution
Add arguments for skipping the dirty repo check and skipping commit changes.