### PR TITLE
Move prerelease behavior into set/bump and allow default bump option

### DIFF
--- a/avakas/avakas.py
+++ b/avakas/avakas.py
@@ -61,43 +61,41 @@ class Avakas():
 
     def bump(self, bump):
         """Bump version"""
-        new_version = None
         old_version = self.version
         if bump == 'patch':
-            new_version = old_version.next_patch()
+            self.version = old_version.next_patch()
         elif bump == 'minor':
-            new_version = old_version.next_minor()
+            self.version = old_version.next_minor()
         elif bump == 'major':
-            new_version = old_version.next_major()
-        elif bump == 'pre':
-            new_version = old_version
-            prereleases = len(new_version.prerelease)
-            if prereleases == 1:
-                new_version.prerelease = (str(
-                                          int(new_version.prerelease[0]) + 1))
-            elif prereleases == 0:
-                new_version.prerelease = ('1')
-            else:
-                new_version = AvakasError("Unexpected version prerelease")
-
+            self.version = old_version.next_major()
         else:
-            new_version = AvakasError("Invalid version component")
+            raise AvakasError("Invalid version component")
 
-        return new_version
+    def make_prerelease(self, prefix=None, build_date=None):
+        """Make current version a prerelease"""
+        release_pos = 1 if prefix else 0
+        if self.version.prerelease:
+            release = self.version.prerelease[release_pos]
+        else:
+            release = 1
+
+        self.apply_prerelease((str(release)),
+                              prefix=prefix,
+                              build_date=build_date)
 
     def apply_metadata(self, *metadata):
         """Apply build metadata to project version"""
         self.version.build += metadata
 
-    def apply_prebuild(self, *prebuild, prefix=None, prebuild_date=None):
+    def apply_prerelease(self, *prebuild, prefix=None, build_date=None):
         """Apply prebuild data to project version"""
-        if not (prefix or prebuild_date):
-            self.version.prerelease += prebuild
-        else:
-            if prefix:
-                self.version.prerelease += (prefix,)
-            if prebuild_date:
-                self.version.prerelease += (prebuild_date,)
+        if prefix:
+            self.version.prerelease += (prefix,)
+
+        self.version.prerelease += prebuild
+
+        if build_date:
+            self.version.prerelease += (build_date,)
 
 
 def register_flavor(flavor):

--- a/tests/integration/autobump.bats
+++ b/tests/integration/autobump.bats
@@ -44,7 +44,7 @@ teardown() {
     commit_message "$REPO" "still here tho"
     avakas_wrapper bump "$REPO" auto
     avakas_wrapper show "$REPO"
-    [ "$output" == "0.3.0" ]    
+    [ "$output" == "0.3.0" ]
 }
 @test "autobump a plain version - major" {
     commit_message "$REPO" "some thing\nbump:major"
@@ -59,11 +59,34 @@ teardown() {
     [ "$output" == "2.0.0" ]
     commit_message "$REPO" "some boring junk\nbump:patch"
     commit_message "$REPO" "slightly less boring junk\nbump:major"
-    commit_message "$REPO" "some boring junk\nbump:minor"    
+    commit_message "$REPO" "some boring junk\nbump:minor"
     commit_message "$REPO" "still here tho"
     avakas_wrapper bump "$REPO" auto
     avakas_wrapper show "$REPO"
-    [ "$output" == "3.0.0" ]    
+    [ "$output" == "3.0.0" ]
+}
+@test "autobump with a default bump - patch" {
+    commit_message "$REPO" "some thing\nbump:major"
+    avakas_wrapper bump "$REPO" auto --default-bump patch
+    avakas_wrapper show "$REPO"
+    [ "$output" == "1.0.0" ]
+    commit_message "$REPO" "some boring junk"
+    commit_message "$REPO" "more boring junk"
+    commit_message "$REPO" "we who are dreamers\nbump:major"
+    avakas_wrapper bump "$REPO" auto --default-bump patch
+    avakas_wrapper show "$REPO"
+    [ "$output" == "2.0.0" ]
+    commit_message "$REPO" "some boring junk\nbump:patch"
+    commit_message "$REPO" "slightly less boring junk\nbump:major"
+    commit_message "$REPO" "some boring junk\nbump:minor"
+    commit_message "$REPO" "still here tho"
+    avakas_wrapper bump "$REPO" auto --default-bump patch
+    avakas_wrapper show "$REPO"
+    [ "$output" == "3.0.0" ]
+    commit_message "$REPO" "some last minute boring junk"
+    avakas_wrapper bump "$REPO" auto --default-bump patch
+    avakas_wrapper show "$REPO"
+    [ "$output" == "3.0.1" ]
 }
 
 @test "autobump a plain version - complex" {
@@ -88,5 +111,5 @@ teardown() {
     commit_message "$REPO" "oh hey feature tho\nbump:minor"
     avakas_wrapper bump "$REPO" auto
     avakas_wrapper show "$REPO"
-    [ "$output" == "1.1.0" ]    
+    [ "$output" == "1.1.0" ]
 }

--- a/tests/integration/build.bats
+++ b/tests/integration/build.bats
@@ -15,96 +15,55 @@ teardown() {
     shared_teardown
 }
 
-@test "show a build version (git only in build component)" {
-    avakas_wrapper show "$REPO" --build
+@test "set build metadata (git only in build component)" {
     REV=$(current_rev $REPO)
-    [ "$output" == "0.0.1+${REV}" ]
+    avakas_wrapper set "$REPO" "0.0.2" --build-meta
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.2+${REV}" ]
 }
 
-@test "show a (jenkins) build version (git only + build number in build component)" {
+@test "set jenkins sourced build metadata (git only + build number in build component)" {
     export BUILD_NUMBER=1
-    avakas_wrapper show "$REPO" --build
-    unset BUILD_NUMBER
     REV=$(current_rev $REPO)
-    [ "$output" == "0.0.1+${REV}.1" ]
+    avakas_wrapper set "$REPO" "0.0.2" --build-meta
+    unset BUILD_NUMBER
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.2+${REV}.1" ]
 }
 
-@test "show a (travis) build version (git only + build number in build component)" {
+@test "set travis-sourced build metadata (git only + build number in build component)" {
     export TRAVIS_BUILD_NUMBER=1
-    avakas_wrapper show "$REPO" --build
     REV=$(current_rev $REPO)
-    [ "$output" == "0.0.1+${REV}.1" ]
+    avakas_wrapper set "$REPO" "0.0.2" --build-meta
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.2+${REV}.1" ]
     unset TRAVIS_BUILD_NUMBER
 }
 
-@test "show a (circleci) build version (git only + build number in build component)" {
+@test "set circleci-sourced build metadata (git only + build number in build component)" {
     export CIRCLE_BUILD_NUM=1
-    avakas_wrapper show "$REPO" --build
     REV=$(current_rev $REPO)
-    [ "$output" == "0.0.1+${REV}.1" ]
+    avakas_wrapper set "$REPO" "0.0.2" --build-meta
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.2+${REV}.1" ]
     unset CIRCLE_BUILD_NUM
 }
 
-@test "show a (gha) build version (git only + build number in build component)" {
+@test "set github-actions-sourced build metadata (git only + build number in build component)" {
     export GITHUB_RUN_ID=abcd
     export GITHUB_RUN_NUMBER=1
-    avakas_wrapper show "$REPO" --build
     REV=$(current_rev $REPO)
-    [ "$output" == "0.0.1+${REV}.abcd.1" ]
+    avakas_wrapper set "$REPO" "0.0.2" --build-meta
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.2+${REV}.abcd.1" ]
     unset GITHUB_RUN_ID
     unset GITHUB_RUN_NUMBER
 }
 
-@test "show a build version (git only in build component with preexisting build component)" {
-    template_skeleton "$REPO" plain "0.0.1+1"
-    avakas_wrapper show "$REPO" --build
+@test "set build metadata (override existing build components with preexisting build component)" {
+    template_skeleton "$REPO" plain "0.0.2+1"
     REV=$(current_rev $REPO)
-    [ "$output" == "0.0.1+1.${REV}" ]
-}
-
-@test "show a build version (git only in prerelease component)" {
-    avakas_wrapper show "$REPO" --pre-build
-    REV=$(current_rev $REPO)
-    [ "$output" == "0.0.1-${REV}" ]
-}
-
-@test "show a build version (git only in prerelease component with preexisting prerelease component)" {
-    template_skeleton "$REPO" plain 0.0.1-1
-    avakas_wrapper show "$REPO" --pre-build
-    REV=$(current_rev $REPO)
-    [ "$output" == "0.0.1-1.${REV}" ]
-}
-
-@test "show a (jenkins) build version (git only + build number in prerelease component)" {
-    export BUILD_NUMBER=1
-    avakas_wrapper show "$REPO" --pre-build
-    unset BUILD_NUMBER
-    REV=$(current_rev $REPO_ORIGIN)
-    [ "$output" == "0.0.1-${REV}.1" ]
-}
-
-@test "show a (travis) build version (git only + build number in prerelease component)" {
-    export TRAVIS_BUILD_NUMBER=1
-    avakas_wrapper show "$REPO" --pre-build
-    REV=$(current_rev $REPO_ORIGIN)
-    [ "$output" == "0.0.1-${REV}.1" ]
-    unset TRAVIS_BUILD_NUMBER
-}
-
-@test "show a (circleci) build version (git only + build number in prerelease component)" {
-    export CIRCLE_BUILD_NUM=1
-    avakas_wrapper show "$REPO" --pre-build
-    REV=$(current_rev $REPO)
-    [ "$output" == "0.0.1-${REV}.1" ]
-    unset CIRCLE_BUILD_NUM
-}
-
-@test "show a (gha) build version (git only + build number in prerelease component)" {
-    export GITHUB_RUN_ID=abcd
-    export GITHUB_RUN_NUMBER=1
-    avakas_wrapper show "$REPO" --pre-build
-    REV=$(current_rev $REPO)
-    [ "$output" == "0.0.1-${REV}.abcd.1" ]
-    unset GITHUB_RUN_ID
-    unset GITHUB_RUN_NUMBER
+    avakas_wrapper set "$REPO" "0.0.2" --build-meta
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.2+${REV}" ]
 }

--- a/tests/integration/plain.bats
+++ b/tests/integration/plain.bats
@@ -48,20 +48,6 @@ teardown() {
     [ "$output" == "1.0.0" ]
 }
 
-@test "bump a plain version - patch to prerelease" {
-    avakas_wrapper bump "$REPO" pre
-    scan_lines "Version updated from 0.0.1 to 0.0.1-1"  "${lines[@]}"
-    avakas_wrapper show "$REPO"
-    [ "$output" == "0.0.1-1" ]
-
-}
-
-@test "show a plain version - specified filename" {
-    plain_version "$REPO" "0.0.1-1" "foo"
-    avakas_wrapper show "$REPO" --filename "foo"
-    [ "$output" == "0.0.1-1" ]
-}
-
 @test "set a plain version - specified filename" {
     plain_version "$REPO" "0.0.1-1" "foo"
     avakas_wrapper set "$REPO" "0.0.2" --filename "foo"

--- a/tests/integration/prerelease.bats
+++ b/tests/integration/prerelease.bats
@@ -6,7 +6,7 @@ load helper
 setup() {
     shared_setup
     REPO_ORIGIN=$(fake_repo)
-    template_skeleton "$REPO_ORIGIN" plain "0.0.1"
+    template_skeleton "$REPO_ORIGIN" plain "0.0.0"
     origin_repo "$REPO_ORIGIN"
     REPO=$(clone_repo $REPO_ORIGIN)
 }
@@ -15,148 +15,154 @@ teardown() {
     shared_teardown
 }
 
-@test "show a prerelease prefix" {
-    avakas_wrapper show "$REPO" --pre-build --pre-build-prefix=alpha
-    [ "$output" == "0.0.1-alpha" ]
+@test "set a prerelease prefix" {
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix=alpha
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-alpha.1" ]
 }
 
-@test "show a prerelease w/prefix and git build" {
-    avakas_wrapper show "$REPO" --pre-build --pre-build-prefix=alpha --build
-    REV=$(current_rev $REPO)
-    [ "$output" == "0.0.1-alpha+${REV}" ]
+@test "set a prerelease w/prefix and git build" {
+  REV=$(current_rev $REPO)
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix=alpha --build
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-alpha.1+${REV}" ]
 }
 
-@test "show a prerelease w/prefix and git (jenkins) build" {
+@test "set a prerelease w/prefix and git (jenkins) build" {
     export BUILD_NUMBER=1
-    avakas_wrapper show "$REPO" --pre-build --pre-build-prefix=alpha --build
     REV=$(current_rev $REPO)
-    [ "$output" == "0.0.1-alpha+${REV}.1" ]
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix=alpha --build
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-alpha.1+${REV}.1" ]
     unset BUILD_NUMBER
 }
 
-@test "show a prerelease w/prefix and git (travis) build" {
+@test "set a prerelease w/prefix and git (travis) build" {
     export TRAVIS_BUILD_NUMBER=1
-    avakas_wrapper show "$REPO" --pre-build --pre-build-prefix=alpha --build
     REV=$(current_rev $REPO)
-    [ "$output" == "0.0.1-alpha+${REV}.1" ]
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix=alpha --build
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-alpha.1+${REV}.1" ]
     unset TRAVIS_BUILD_NUMBER
 }
 
-@test "show a prerelease w/prefix and git (circle) build" {
+@test "set a prerelease w/prefix and git (circle) build" {
     export CIRCLE_BUILD_NUM=1
-    avakas_wrapper show "$REPO" --pre-build --pre-build-prefix=alpha --build
     REV=$(current_rev $REPO)
-    [ "$output" == "0.0.1-alpha+${REV}.1" ]
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix=alpha --build
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-alpha.1+${REV}.1" ]
     unset CIRCLE_BUILD_NUM
 }
 
-@test "show a prerelease w/prefix and git (gha) build" {
+@test "set a prerelease w/prefix and git (gha) build" {
     export GITHUB_RUN_ID=abcd
     export GITHUB_RUN_NUMBER=1
-    avakas_wrapper show "$REPO" --pre-build --pre-build-prefix=alpha --build
     REV=$(current_rev $REPO)
-    [ "$output" == "0.0.1-alpha+${REV}.abcd.1" ]
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix=alpha --build
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-alpha.1+${REV}.abcd.1" ]
     unset GITHUB_RUN_ID
     unset GITHUB_RUN_NUMBER
 }
 
-@test "show a prerelease w/date" {
-    avakas_wrapper show "$REPO" --pre-build --pre-build-date
+@test "set a prerelease w/date" {
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-date
     ALMOST="$(TZ='UTC' date "+%Y%m%d%H%M")"
     MATCH="$(rev <<< "$output" | cut -c 3- | rev)"
-    [ "$MATCH" == "0.0.1-${ALMOST}" ]
+    grep -v "0.0.1\-1.${ALMOST}[0-9]{2}" <<< "$output"
 }
 
-@test "show a prerelease w/date and git build" {
-    avakas_wrapper show "$REPO" --pre-build  --pre-build-date --build
-    REV=$(current_rev $REPO)
+@test "set a prerelease w/date and git build" {
+  REV=$(current_rev $REPO)
+    avakas_wrapper bump "$REPO" patch --prerelease  --prerelease-date --build
     ALMOST="$(TZ='UTC' date "+%Y%m%d%H%M")"
     grep -v "0.0.1\-${ALMOST}[0-9]{2}\+${REV}" <<< "$output"
 }
 
-@test "show a prerelease w/date and git (jenkins) build" {
+@test "set a prerelease w/date and git (jenkins) build" {
     export BUILD_NUMBER=1
-    avakas_wrapper show "$REPO" --pre-build --pre-build-date --build
     REV=$(current_rev $REPO)
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-date --build
     ALMOST="$(TZ='UTC' date "+%Y%m%d%H%M")"
     grep -v "0.0.1\-${ALMOST}[0-9]{2}\+${REV}.1" <<< "$output"
     unset BUILD_NUMBER
 }
 
-@test "show a prerelease w/date and git (travis) build" {
+@test "set a prerelease w/date and git (travis) build" {
     export TRAVIS_BUILD_NUMBER=1
-    avakas_wrapper show "$REPO" --pre-build --pre-build-date --build
     REV=$(current_rev $REPO)
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-date --build
     ALMOST="$(TZ='UTC' date "+%Y%m%d%H%M")"
     grep -v "0.0.1\-${ALMOST}[0-9]{2}\+${REV}.1" <<< "$output"
     unset TRAVIS_BUILD_NUMBER
 }
 
-@test "show a prerelease w/date and git (circle) build" {
+@test "set a prerelease w/date and git (circle) build" {
     export CIRCLE_BUILD_NUM=1
-    avakas_wrapper show "$REPO" --pre-build --pre-build-date --build
     REV=$(current_rev $REPO)
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-date --build
     ALMOST="$(TZ='UTC' date "+%Y%m%d%H%M")"
     grep -v "0.0.1\-${ALMOST}[0-9]{2}\+${REV}.1" <<< "$output"
     unset CIRCLE_BUILD_NUM
 }
 
-@test "show a prerelease w/date and git (gha) build" {
+@test "set a prerelease w/date and git (gha) build" {
     export GITHUB_RUN_ID=abcd
     export GITHUB_RUN_NUMBER=1
-    avakas_wrapper show "$REPO" --pre-build --pre-build-date --build
     REV=$(current_rev $REPO)
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-date --build
     ALMOST="$(TZ='UTC' date "+%Y%m%d%H%M")"
     grep -v "0.0.1\-${ALMOST}[0-9]{2}\+${REV}.abc.1}" <<< "$output"
     unset GITHUB_RUN_ID
     unset GITHUB_RUN_NUMBER
 }
 
-@test "show a prerelease w/prefix and date" {
-    avakas_wrapper show "$REPO" --pre-build --pre-build-date --pre-build-prefix=alpha
+@test "set a prerelease w/prefix and date" {
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-date --prerelease-prefix=alpha
     ALMOST="$(TZ='UTC' date "+%Y%m%d%H%M")"
     grep -v "0.0.1-alpha.${ALMOST}[0-9]{2}" <<< "$output"
 }
 
-@test "show a prerelease w/prefix and date and git build" {
-    avakas_wrapper show "$REPO" --pre-build --pre-build-date --pre-build-prefix=alpha --build
-    REV=$(current_rev $REPO)
+@test "set a prerelease w/prefix and date and git build" {
+  REV=$(current_rev $REPO)
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-date --prerelease-prefix=alpha --build
     ALMOST="$(TZ='UTC' date "+%Y%m%d%H%M")"
     grep -v "0.0.1\-alpha.${ALMOST}[0-9]{2}\+${REV}" <<< "$output"
 }
 
-@test "show a prerelease w/prefix and date and git (jenkins) build" {
+@test "set a prerelease w/prefix and date and git (jenkins) build" {
     export BUILD_NUMBER=1
-    avakas_wrapper show "$REPO" --pre-build --pre-build-date --pre-build-prefix=alpha --build
     REV=$(current_rev $REPO)
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-date --prerelease-prefix=alpha --build
     ALMOST="$(TZ='UTC' date "+%Y%m%d%H%M")"
     grep -v "0.0.1\-alpha.${ALMOST}[0-9]{2}\+${REV}.1" <<< "$output"
     unset BUILD_NUMBER
 }
 
-@test "show a prerelease w/prefix and date and git (travis) build" {
+@test "set a prerelease w/prefix and date and git (travis) build" {
     export TRAVIS_BUILD_NUMBER=1
-    avakas_wrapper show "$REPO" --pre-build --pre-build-date --pre-build-prefix=alpha --build
     REV=$(current_rev $REPO)
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-date --prerelease-prefix=alpha --build
     ALMOST="$(TZ='UTC' date "+%Y%m%d%H%M")"
     grep -v "0.0.1\-alpha.${ALMOST}[0-9]{2}\+${REV}.1" <<< "$output"
     unset TRAVIS_BUILD_NUMBER
 }
 
-@test "show a prerelease w/prefix and date and git (circle) build" {
+@test "set a prerelease w/prefix and date and git (circle) build" {
     export CIRCLE_BUILD_NUM=1
-    avakas_wrapper show "$REPO" --pre-build --pre-build-date --pre-build-prefix=alpha --build
     REV=$(current_rev $REPO)
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-date --prerelease-prefix=alpha --build
     ALMOST="$(TZ='UTC' date "+%Y%m%d%H%M")"
     grep -v "0.0.1\-alpha.${ALMOST}[0-9]{2}\+${REV}.1" <<< "$output"
     unset CIRCLE_BUILD_NUM
 }
 
-@test "show a prerelease w/prefix and date and git (gha) build" {
+@test "set a prerelease w/prefix and date and git (gha) build" {
     export GITHUB_RUN_ID=abcd
     export GITHUB_RUN_NUMBER=1
-    avakas_wrapper show "$REPO" --pre-build --pre-build-date --pre-build-prefix=alpha --build
     REV=$(current_rev $REPO)
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-date --prerelease-prefix=alpha --build
     ALMOST="$(TZ='UTC' date "+%Y%m%d%H%M")"
     grep -v "0.0.1\-alpha.${ALMOST}[0-9]{2}\+${REV}.abc.1}" <<< "$output"
     unset GITHUB_RUN_ID


### PR DESCRIPTION
## Problem
Semver 2.0§9 states:
>Pre-release versions have a lower precedence than the associated normal version.

Avakas presently behaves by appending prerelease to whatever the present version detected version is. An example failure case would be development on a feature branch taken from 0.0.2 of HEAD. If the next _desired_ bump is 0.0.3, a build from this feature branch would wind up as 0.0.2-1

Additionally, Avakas concatenates pre-release identifiers without dot-separation.

Semver 2.0§10 states:
>Build metadata MUST be ignored when determining version precedence.

However, Avakas' current behavior takes build metadata into account with precedence.

While not strictly defined within semver, git hashes appear to be discouraged within prerelease and seem more appropriately scoped for build metadata.

Lastly, Avakas' behavior currently applies prerelease/build metadata on both setting a version or non-destructively within showing a version.

## Solution
A desired bump level should still be used when creating a prerelease. A case where we would want this to be accurate:

A feature branch taken from 0.0.2 of HEAD. If the next _desired_ bump is 0.0.3, a build from this feature branch will be 0.0.3-1. Once the feature branch is merged into HEAD, it'll use the next desired bump of HEAD creating 0.0.3

I removed prerelease flags from `show` to not mutate the actual version as detected by the flavor at time of invocation.

Prerelease functionality is now an argument to a set or bump action.

:warning: This would be a breaking change, and intended for a #major release