### PR TITLE
add more ways to hint at bump levels in commit msgs

### DIFF
--- a/avakas/cli.py
+++ b/avakas/cli.py
@@ -142,7 +142,8 @@ def determine_bump(repo, opt):
     and look for hints that we want to "automatically" bump
     our version"""
     vsn = None
-    reg = re.compile(r'bump:(?P<bump>(patch|minor|major)).*', re.MULTILINE)
+    reg = re.compile(r'(\#|bump:|\[)(?P<bump>(patch|minor|major))(.*|\])',
+                     re.MULTILINE)
     for commit in repo.iter_commits(opt.branch):
         # we go iterate back to the last time we bumped the version
         if commit.message.startswith('Version bumped to'):

--- a/avakas/flavors/base.py
+++ b/avakas/flavors/base.py
@@ -96,7 +96,8 @@ class AvakasLegacy(Avakas):
         our version"""
         self.repo = self.__load_git()
         vsn = None
-        reg = re.compile(r'bump:(?P<bump>(patch|minor|major)).*', re.MULTILINE)
+        reg = re.compile(r'(\#|bump:|\[)(?P<bump>(patch|minor|major))(.*|\])',
+                         re.MULTILINE)
         for commit in self.repo.iter_commits(self.options['branch']):
             # we go iterate back to the last time we bumped the version
             if commit.message.startswith('Version bumped to'):


### PR DESCRIPTION
This allows more ways to hint at version bump level. Examples:

* `bump:patch`
* `#patch`
* `[patch]`