### PR TITLE
release on tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,32 +57,5 @@ jobs:
             mkdir -p ~/.ssh/
             ssh-keyscan github.com >> ~/.ssh/known_hosts
             make install
-            avakas bump . auto --branch=mainline
+            avakas bump . auto --branch=mainline --default-bump patch
             ssh-agent -k
-  publish:
-    if: startsWith(github.ref, 'refs/tags')
-    runs-on: "ubuntu-latest"
-    needs: "test"
-    steps:
-      - uses: "actions/checkout@v2"
-        with:
-          fetch-depth: 1
-      - name: "Set up Python"
-        uses: "actions/setup-python@v2"
-        with:
-          python-version: "3.8"
-      - name: "Build a package"
-        run: "make package"
-      - name: "Publish to pypi"
-        uses: "pypa/gh-action-pypi-publish@v1.3.1"
-        with:
-          user: "__token__"
-          password: "${{ secrets.PYPI_TOKEN }}"
-      - name: "Build and push docker bits"
-        uses: "docker/build-push-action@v1"
-        with:
-          username: "${{ secrets.DOCKER_USER }}"
-          password: "${{ secrets.DOCKER_PASSWORD }}"
-          repository: "otakup0pe/avakas"
-          tag_with_ref: true
-          tags: "latest"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - "mainline"
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
   pull_request:
     branches:
       - "mainline"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+---
+name: "release"
+
+on:
+  release:
+    types: [prereleased, released]
+
+jobs:
+  publish:
+    if: startsWith(github.ref, 'refs/tags')
+    runs-on: "ubuntu-latest"
+    needs: "test"
+    steps:
+      - uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 1
+      - name: "Set up Python"
+        uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.8"
+      - name: "Build a package"
+        run: "make package"
+      - name: "Publish to pypi"
+        uses: "pypa/gh-action-pypi-publish@v1.3.1"
+        with:
+          user: "__token__"
+          password: "${{ secrets.PYPI_TOKEN }}"
+      - name: "Build and push docker bits"
+        uses: "docker/build-push-action@v1"
+        with:
+          username: "${{ secrets.DOCKER_USER }}"
+          password: "${{ secrets.DOCKER_PASSWORD }}"
+          repository: "otakup0pe/avakas"
+          tag_with_ref: true
+          tags: "latest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: "release"
 
 on:
   release:
-    types: [prereleased, released]
+    types: [created]
 
 jobs:
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,7 @@ on:
 
 jobs:
   publish:
-    if: startsWith(github.ref, 'refs/tags')
     runs-on: "ubuntu-latest"
-    needs: "test"
     steps:
       - uses: "actions/checkout@v2"
         with:


### PR DESCRIPTION
## Problem
Avakas currently only bumps versions if a bump hint is detected. However, add a default bump of patch would mean new versions could get pushed to pypi too frequently.

## Solution
Publish to pypi on creation of a GitHub release from a tag. A repo maintainer would just need to go to the Tags section, and select Create Release to trigger the publish action.

![image](https://user-images.githubusercontent.com/621936/102534323-6c69b280-405b-11eb-9edd-84320bbb52e0.png)

Since testing this is tricky and to not dirty history with the project, I've currently targeted the new workflow on creation so that a draft release can be made.