### PR TITLE
Relaxing autobump: allow for space after `:`

### DIFF
--- a/avakas/flavors/base.py
+++ b/avakas/flavors/base.py
@@ -96,8 +96,10 @@ class AvakasLegacy(Avakas):
         our version"""
         self.repo = self.__load_git()
         vsn = None
-        reg = re.compile(r'(\#|bump:|\[)(?P<bump>(patch|minor|major))(.*|\])',
-                         re.MULTILINE)
+        reg = re.compile(
+            r'(\#|bump:\s*|\[)(?P<bump>(patch|minor|major))(.*|\])',
+            re.MULTILINE)
+
         for commit in self.repo.iter_commits(self.options['branch']):
             # we go iterate back to the last time we bumped the version
             if commit.message.startswith('Version bumped to'):


### PR DESCRIPTION
following the Robustness principle, `bump: patch` seems reasonable There may be good reason to allow for whitespace other places (after `#` and inside `[]`, but those feel less obvious to me (and are not what bit me).