### PR TITLE
Tjachetta/add test for successive prereleases

### DIFF
--- a/tests/integration/prerelease.bats
+++ b/tests/integration/prerelease.bats
@@ -169,11 +169,27 @@ teardown() {
     unset GITHUB_RUN_NUMBER
 }
 
-@test "increment prerelease multiple times w/ prefix" {
+@test "minimal increment prerelease multiple times w/ prefix" {
     avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix beta
     avakas_wrapper show "$REPO"
     [ "$output" == "0.0.1-beta.1" ]
     avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix beta
     avakas_wrapper show "$REPO"
     [ "$output" == "0.0.1-beta.2" ]
+}
+
+
+@test "increment prerelease multiple times w/ prefix, changing prefix" {
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix beta
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-beta.1" ]
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix beta
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-beta.2" ]
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix beta
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-beta.3"]
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix rc
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-rc.1"]
 }

--- a/tests/integration/prerelease.bats
+++ b/tests/integration/prerelease.bats
@@ -168,3 +168,12 @@ teardown() {
     unset GITHUB_RUN_ID
     unset GITHUB_RUN_NUMBER
 }
+
+@test "increment prerelease multiple times w/ prefix" {
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix beta
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-beta.1" ]
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix beta
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-beta.2" ]
+}


### PR DESCRIPTION
hen one attempts to do two prerelease bumps for the same bump, the pre-release component does not get incremented properly. These tests will fail with the current code