### PR TITLE
Tjachetta/test in containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ avakas.egg-info
 .coverage
 version
 .tox
+.local
+.cache

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ avakas.egg-info
 .ci-env
 .coverage
 version
+.tox

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
+.PHONY = all testenv install package test test_in_containers test_in_container_37 test_in_container_38 clean container
+
+HERE := $(shell pwd)
+
 ifndef CI
-	CI_ENV=$(shell pwd)/.ci-env/bin/
+	CI_ENV=$(HERE)/.ci-env/bin/
 endif
+
 
 all: test package
 
@@ -25,8 +30,23 @@ test: testenv install
 	$(CI_ENV)coverage report -m
 	test -z $(TRAVIS) && $(CI_ENV)coverage erase || true
 
+generate_testing_artifact: clean
+	tox --sdistonly
+
+test_in_container_37: #generate_testing_artifact
+	docker run -v "$(HERE):/src" python:3.7 bash -c 'pip install tox; cd /src;tox -e py37'
+
+test_in_container_38: generate_testing_artifact
+	docker run -v "$(HERE):/src" python:3.8 bash -c 'pip install tox; cd /src;tox -e py38'
+
+
+# Long term these versions should not be hardcoded, upon
+# viability of the tox-via-docker plugin, that should be used.
+test_in_containers: test_in_container_37 test_in_container_38
+
+
 clean:
-	rm -rf .bats-git .bats .ci-env avakas.egg-info dist build .coverage
+	rm -rf .bats-git .bats .ci-env avakas.egg-info dist build .coverage .tox
 	python setup.py clean
 
 container:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY = all testenv install package test test_in_containers test_in_container_37 test_in_container_38 clean container
+.PHONY = all testenv install package test test_in_containers test_in_container_37 test_in_container_38 clean container version
 
 HERE := $(shell pwd)
 HERE_OWNERSHIP := $(shell stat -c '%u:%g' $(HERE))
 FIX_OWNERSHIP := chown -R $(HERE_OWNERSHIP)
 
-SETUP_CONTAINER_FOR_TESTS := pip install tox; cd /src;make clean;pip install -r requirements.txt
+SETUP_CONTAINER_FOR_TESTS := pip install tox; cd /src;pip install -r requirements.txt
 
 ifndef CI
 	CI_ENV=$(HERE)/.ci-env/bin/
@@ -19,9 +19,11 @@ testenv:
 		(echo "Outside CI" && .ci-env/bin/pip install -r requirements.txt -r requirements-dev.txt --upgrade) || \
 		(echo "Within CI" && pip install -r requirements.txt -r requirements-dev.txt)
 
-install:
-	python -m avakas show . --flavor "git-native"
-	python setup.py install
+version: testenv
+	$(CI_ENV)python -m avakas show . --flavor "git-native"
+
+install: testenv version
+	$(CI_ENV)python setup.py install
 
 package:
 	python setup.py sdist
@@ -34,7 +36,7 @@ test: testenv install
 	$(CI_ENV)coverage report -m
 	test -z $(TRAVIS) && $(CI_ENV)coverage erase || true
 
-generate_testing_artifact: clean
+generate_testing_artifact: version
 	tox --sdistonly
 
 test_in_container_37: generate_testing_artifact
@@ -48,10 +50,13 @@ test_in_container_38: generate_testing_artifact
 # viability of the tox-via-docker plugin, that should be used.
 test_in_containers: test_in_container_37 test_in_container_38
 
-
 clean:
+	# The touch and remove is because the setup.py depends on a file existing
+	# which isn't actually tracked in git
+	touch version
 	rm -rf .bats-git .bats .ci-env avakas.egg-info dist build .coverage .tox
 	python setup.py clean
+	rm version
 
 container:
 	docker build \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ HERE := $(shell pwd)
 HERE_OWNERSHIP := $(shell stat -c '%u:%g' $(HERE))
 FIX_OWNERSHIP := chown -R $(HERE_OWNERSHIP)
 
-SETUP_CONTAINER_FOR_TESTS := pip install tox; cd /src;pip install -r requirements.txt
+SETUP_CONTAINER_FOR_TESTS := cd /src;pip install -r requirements.txt
 
 ifndef CI
 	CI_ENV=$(HERE)/.ci-env/bin/

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test: testenv install
 generate_testing_artifact: clean
 	tox --sdistonly
 
-test_in_container_37: #generate_testing_artifact
+test_in_container_37: generate_testing_artifact
 	docker run -v "$(HERE):/src" python:3.7 bash -c '$(SETUP_CONTAINER_FOR_TESTS); tox -e py37;$(FIX_OWNERSHIP) /src'
 
 test_in_container_38: generate_testing_artifact

--- a/README.md
+++ b/README.md
@@ -102,6 +102,20 @@ $ cp ~/.ssh/id_rsa /tmp/ssh-avakas-working
 $ docker run  -v $(pwd):/app -v /tmp/ssh-avakas-working:/etc/avakas otakup0pe/avakas set /app 0.0.1
 ```
 
+# Development
+
+## Local Testing
+
+`make test_in_containers` will run all integration tests against all supported
+minor versions of Python. It does not currently run any style or lint tests,
+and the coverage report it generates points to an absolute path on the
+container (`/src/`) and is therefore not terribly useful, but it does run all
+of the integration tests (the other tests and output are planned to be added).
+
+`make test` will work to run tests against whatever version of Python is
+`python3` on your host. It also runs style and lint checks, and generates a
+coverage report from the integration tests.
+
 # License
 
 [MIT](https://github.com/otakup0pe/avakas/blob/master/LICENSE)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -127,3 +127,20 @@ typed-ast==1.4.1; implementation_name == "cpython" and python_version < "3.8" \
     --hash=sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b
 wrapt==1.12.1 \
     --hash=sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7
+gitdb==4.0.5 \
+    --hash=sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac \
+    --hash=sha256:c9e1f2d0db7ddb9a704c2a0217be31214e91a4fe1dea1efad19ae42ba0c285c9
+parsimonious==0.7.0 \
+    --hash=sha256:396d424f64f834f9463e81ba79a331661507a21f1ed7b644f7f6a744006fd938
+py==1.10.0 \
+    --hash=sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3 \
+    --hash=sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a
+pyparsing==2.4.7 \
+    --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
+    --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b
+smmap==3.0.4 \
+    --hash=sha256:54c44c197c819d5ef1991799a7e30b662d1e520f2ac75c9efbeb54a742214cf4 \
+    --hash=sha256:9c98bbd1f9786d22f14b3d4126894d56befb835ec90cef151af566c7e19b5d24
+tox==3.21.0 \
+    --hash=sha256:5efda30ad73e662c3844ac51ce1381bf28f61063773e06996aa8b6277133a7c0 \
+    --hash=sha256:8cccede64802e78aa6c69f81051b25f0706639d1cbbb34d9366ce00c70ee054f

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,8 @@ gitdb==4.0.5; python_version >= "3.4" \
 gitpython==3.1.11; python_version >= "3.4" \
     --hash=sha256:6eea89b655917b500437e9668e4a12eabdcf00229a0df1762aabd692ef9b746b \
     --hash=sha256:befa4d101f91bad1b632df4308ec64555db684c360bd7d2130b4807d49ce86b8
+importlib-metadata==3.4.0; python_version == "3.7" \
+    --hash=sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771
 packaging==20.8 \
     --hash=sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858 \
     --hash=sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093
@@ -44,6 +46,8 @@ toml==0.10.2 \
 tox==3.21.0 \
     --hash=sha256:5efda30ad73e662c3844ac51ce1381bf28f61063773e06996aa8b6277133a7c0 \
     --hash=sha256:8cccede64802e78aa6c69f81051b25f0706639d1cbbb34d9366ce00c70ee054f
+typing-extensions==3.7.4.3; python_version == "3.7" \
+    --hash=sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918
 virtualenv==20.2.2 \
     --hash=sha256:54b05fc737ea9c9ee9f8340f579e5da5b09fb64fd010ab5757eb90268616907c \
     --hash=sha256:b7a8ec323ee02fb2312f098b6b4c9de99559b462775bc8fe3627a73706603c1b

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,5 @@ typing-extensions==3.7.4.3; python_version == "3.7" \
 virtualenv==20.2.2 \
     --hash=sha256:54b05fc737ea9c9ee9f8340f579e5da5b09fb64fd010ab5757eb90268616907c \
     --hash=sha256:b7a8ec323ee02fb2312f098b6b4c9de99559b462775bc8fe3627a73706603c1b
+zipp==3.4.0 \
+    --hash=sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,49 @@
+appdirs==1.4.4 \
+    --hash=sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41 \
+    --hash=sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
+distlib==0.3.1 \
+    --hash=sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb \
+    --hash=sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1
 erl-terms==0.1.5 \
     --hash=sha256:bd4157f6d34047248914ef3800e8715ecdef0e2ec93e3b8d83857614fe28b6f2
+filelock==3.0.12 \
+    --hash=sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59 \
+    --hash=sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836
 gitdb==4.0.5; python_version >= "3.4" \
     --hash=sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac \
     --hash=sha256:c9e1f2d0db7ddb9a704c2a0217be31214e91a4fe1dea1efad19ae42ba0c285c9
 gitpython==3.1.11; python_version >= "3.4" \
     --hash=sha256:6eea89b655917b500437e9668e4a12eabdcf00229a0df1762aabd692ef9b746b \
     --hash=sha256:befa4d101f91bad1b632df4308ec64555db684c360bd7d2130b4807d49ce86b8
+packaging==20.8 \
+    --hash=sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858 \
+    --hash=sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093
 parsimonious==0.7.0 \
     --hash=sha256:396d424f64f834f9463e81ba79a331661507a21f1ed7b644f7f6a744006fd938
 semantic-version==2.8.5; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0") \
     --hash=sha256:45e4b32ee9d6d70ba5f440ec8cc5221074c7f4b0e8918bdab748cc37912440a9 \
     --hash=sha256:d2cb2de0558762934679b9a104e82eca7af448c9f4974d1f3eeccff651df8a54
+pluggy==0.13.1 \
+    --hash=sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0 \
+    --hash=sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d
+py==1.10.0 \
+    --hash=sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3 \
+    --hash=sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a
+pyparsing==2.4.7 \
+    --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
+    --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b
 six==1.15.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" \
     --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced \
     --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259
 smmap==3.0.4; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" \
     --hash=sha256:54c44c197c819d5ef1991799a7e30b662d1e520f2ac75c9efbeb54a742214cf4 \
     --hash=sha256:9c98bbd1f9786d22f14b3d4126894d56befb835ec90cef151af566c7e19b5d24
+toml==0.10.2 \
+    --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
+    --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
+tox==3.21.0 \
+    --hash=sha256:5efda30ad73e662c3844ac51ce1381bf28f61063773e06996aa8b6277133a7c0 \
+    --hash=sha256:8cccede64802e78aa6c69f81051b25f0706639d1cbbb34d9366ce00c70ee054f
+virtualenv==20.2.2 \
+    --hash=sha256:54b05fc737ea9c9ee9f8340f579e5da5b09fb64fd010ab5757eb90268616907c \
+    --hash=sha256:b7a8ec323ee02fb2312f098b6b4c9de99559b462775bc8fe3627a73706603c1b

--- a/scripts/integration
+++ b/scripts/integration
@@ -19,7 +19,7 @@ if [ ! -d "$BATSBIN" ] ; then
     ./install.sh "$BATSBIN"
 fi
 
-if [ -z "$CI" ] ; then
+if [ -z "$CI" ]  && [ -z "$VIRTUAL_ENV" ]; then
     . "${ROOTDIR}/.ci-env/bin/activate"
 fi
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ setenv =
   TERM = dumb
   PATH = {env:PATH}{:}/home/tjachetta/src/avakas/scripts
 deps = 
-    pytest
-    coverage
+    -rrequirements.txt
+    -rrequirements-dev.txt
 commands = {toxinidir}/scripts/integration
 distshare = {toxinidir}/.tox/builds
 [testenv:clean]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist = clean,py37,py38
+[testenv]
+setenv =
+  TERM = dumb
+  PATH = {env:PATH}{:}/home/tjachetta/src/avakas/scripts
+deps = 
+    pytest
+    coverage
+commands = {toxinidir}/scripts/integration
+distshare = {toxinidir}/.tox/builds
+[testenv:clean]
+deps = coverage
+skip_install = true
+commands = coverage erase


### PR DESCRIPTION
In order to make it possible to test avakas against Python versions which are not installed on the current host, using the official Python docker images should provide us with more portable testing.

There is a plugin in development to allow this as a simple tox parameter, and when that is finished (I may start contributing), that should be used, but in the meantime, I rather like this

 * does not change the existing test target