### PR TITLE
Fix #68: git flavor autobumps failing to detect previous releases

### DIFF
--- a/avakas/flavors/git.py
+++ b/avakas/flavors/git.py
@@ -68,9 +68,10 @@ class AvakasGitNative(Avakas):
         vsn = None
         reg = re.compile(r'(\#|bump:|\[)(?P<bump>(patch|minor|major))(.*|\])',
                          re.MULTILINE)
+        tagged_commits = set(tag.commit for tag in self.repo.tags)
         for commit in self.repo.iter_commits(self.options['branch']):
             # we go iterate back to the last time we bumped the version
-            if commit.message.startswith('Version bumped to'):
+            if commit in tagged_commits:
                 break
 
             res = reg.search(commit.message)

--- a/tests/integration/autobump.bats
+++ b/tests/integration/autobump.bats
@@ -230,6 +230,24 @@ teardown() {
     avakas_wrapper show "$REPO"
     [ "$output" == "1.1.0" ]
 }
+
+@test "autobump multiple times with one commit" {
+    cd $REPO
+    commit_message "$REPO" "whorp\nbump:patch"
+    avakas_wrapper bump "$REPO" auto
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.2" ]
+    avakas_wrapper bump "$REPO" auto
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.2" ]
+    avakas_wrapper bump "$REPO" auto
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.2" ]
+    avakas_wrapper bump "$REPO" auto
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.2" ]
+}
+
 @test "autobump with no commit" {
     local rev=$(git rev-parse --verify HEAD | cut -c 1-7)
     avakas_wrapper show "$REPO"

--- a/tests/integration/gitnative.bats
+++ b/tests/integration/gitnative.bats
@@ -36,3 +36,28 @@ teardown() {
     scan_lines "0.0.2" "${lines[@]}"
     [ -e "$REPO/version" ]
 }
+
+@test "autobump git-native version once" {
+    cd $REPO
+    commit_message "$REPO" "you're probably not gonna read this anyway\nbump:patch"
+    avakas_wrapper bump "$REPO" auto --flavor "git-native"
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.2" ]
+}
+
+@test "autobump git-native versions multiple times" {
+    cd $REPO
+    commit_message "$REPO" "whorp\nbump:patch"
+    avakas_wrapper bump "$REPO" auto  --flavor "git-native"
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.2" ]
+    avakas_wrapper bump "$REPO" auto  --flavor "git-native"
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.2" ]
+    avakas_wrapper bump "$REPO" auto  --flavor "git-native"
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.2" ]
+    avakas_wrapper bump "$REPO" auto  --flavor "git-native"
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.2" ]
+}


### PR DESCRIPTION
Adds tests to demonstrate behavior when one would run `avakas bump auto` more than once after any single hint, avakas would continue to bump every time `avakas bump auto` was run.

fixes issue #68 , unless I'm mistaken