### PR TITLE
Fix successive prereleases bug (issue 63)

### DIFF
--- a/avakas/avakas.py
+++ b/avakas/avakas.py
@@ -49,6 +49,7 @@ class Avakas():
     @property
     def version(self):
         """Get version"""
+
         tag_prefix = self.options.get('tag_prefix', '')
         return "%s%s" % (tag_prefix, self._version)
 

--- a/avakas/avakas.py
+++ b/avakas/avakas.py
@@ -105,15 +105,13 @@ class Avakas():
             return False
 
         if bump == 'patch':
-            bump_method = self._version.next_patch
+            self._version = self._version.next_patch()
         elif bump == 'minor':
-            bump_method = self._version.next_minor
+            self._version = self._version.next_minor()
         elif bump == 'major':
-            bump_method = self._version.next_major
+            self._version = self._version.next_major()
         else:
             raise AvakasError("Invalid version component")
-
-        self._version = bump_method()
 
         if prerelease:
             prerelease_version = self.get_next_prerelease_version(

--- a/avakas/avakas.py
+++ b/avakas/avakas.py
@@ -109,7 +109,9 @@ class Avakas():
                                   prefix=prerelease_prefix,
                                   build_date=build_date)
 
-        assert self._version != original
+        if self._version == original:
+            msg = "Attempted to set the version to its previous value!"
+            raise AvakasError(msg)
 
         return True
 

--- a/avakas/cli.py
+++ b/avakas/cli.py
@@ -8,9 +8,9 @@ For more information see https://github.com/otakup0pe/avakas
 
 from __future__ import print_function
 
+import datetime
 import os
 import sys
-from datetime import datetime
 import argparse
 
 from git import Repo
@@ -41,14 +41,6 @@ def add_metadata(project, buildmeta=False, **kwargs):
         metadata += ci_build_meta()
         project.apply_metadata(*metadata)
 
-    now = None
-    if kwargs['prerelease_date']:
-        time_fmt = "%Y%m%d%H%M%S"
-        now = datetime.utcnow().strftime(time_fmt)
-
-    if kwargs['prerelease']:
-        project.make_prerelease(prefix=kwargs['prerelease_prefix'],
-                                build_date=now)
     return project
 
 
@@ -76,7 +68,7 @@ def cli_show_version(**kwargs):
     print("%s" % str(project.version))
 
 
-def cli_bump_version(**kwargs):
+def cli_bump_version(prerelease_date=False, **kwargs):
     """Bump the flavour specific version for a project."""
     project = detect_project_flavor(**kwargs)
     if not project.read():
@@ -85,7 +77,15 @@ def cli_bump_version(**kwargs):
 
     bump = kwargs['level'][0]
 
-    if not project.bump(bump=bump):
+    if prerelease_date is True:
+        time_fmt = "%Y%m%d%H%M%S"
+        prerelease_date = datetime.datetime.utcnow().strftime(time_fmt)
+
+    if not project.bump(
+            bump=bump,
+            prerelease=kwargs['prerelease'],
+            prerelease_prefix=kwargs['prerelease_prefix'],
+            build_date=prerelease_date):
         sys.exit(0)
     project = add_metadata(project, **kwargs)
     project.write()

--- a/avakas/cli.py
+++ b/avakas/cli.py
@@ -29,14 +29,14 @@ def git_rev(directory):
     return str(get_repo(directory).head.commit)[0:8]
 
 
-def add_metadata(project, **kwargs):
+def add_metadata(project, buildmeta=False, **kwargs):
     """
     Add metadata for set/bump actions
     """
     directory = kwargs['directory'][0]
 
     git_str = str(git_rev(directory))
-    if kwargs['buildmeta']:
+    if buildmeta:
         metadata = (git_str,)
         metadata += ci_build_meta()
         project.apply_metadata(*metadata)

--- a/avakas/cli.py
+++ b/avakas/cli.py
@@ -8,7 +8,6 @@ For more information see https://github.com/otakup0pe/avakas
 
 from __future__ import print_function
 
-import datetime
 import os
 import sys
 import argparse

--- a/avakas/flavors/base.py
+++ b/avakas/flavors/base.py
@@ -124,6 +124,7 @@ class AvakasLegacy(Avakas):
 
     def write_versionfile(self):
         """Write the version file"""
+
         path = os.path.join(self.directory, self.version_filename)
         version_file = open(path, 'w')
         version_file.write("%s\n" % self.version)

--- a/avakas/flavors/base.py
+++ b/avakas/flavors/base.py
@@ -142,7 +142,10 @@ class AvakasLegacy(Avakas):
                 tag = self.__create_git_tag()
                 self.__git_push(tag=tag)
 
-    def bump(self, bump=None):
+    def bump(self,
+             bump=None,
+             prerelease=False,
+             prerelease_prefix=None, build_date=None):
         """
         When using 'auto', flavor will attempt to determine whether or not
         the project needs to be bumped from git log history. If keywords are
@@ -155,7 +158,11 @@ class AvakasLegacy(Avakas):
             if bump is None and self.options['default_bump']:
                 bump = self.options['default_bump']
 
-        return super().bump(bump=bump)
+        return super().bump(
+            bump=bump,
+            prerelease=prerelease,
+            prerelease_prefix=prerelease_prefix,
+            build_date=build_date)
 
     def read(self):
         """

--- a/avakas/flavors/git.py
+++ b/avakas/flavors/git.py
@@ -102,7 +102,10 @@ class AvakasGitNative(Avakas):
                 tag = self.__create_git_tag()
                 self.__git_push(tag=tag)
 
-    def bump(self, bump=None):
+    def bump(self,
+             bump=None,
+             prerelease=False,
+             prerelease_prefix=None, build_date=None):
         """
         When using 'auto', flavor will attempt to determine whether or not
         the project needs to be bumped from git log history. If keywords are
@@ -115,7 +118,11 @@ class AvakasGitNative(Avakas):
             if bump is None and self.options['default_bump']:
                 bump = self.options['default_bump']
 
-        return super().bump(bump=bump)
+        return super().bump(
+            bump=bump,
+            prerelease=prerelease,
+            prerelease_prefix=prerelease_prefix,
+            build_date=build_date)
 
     def read(self):
         git = Git(self.directory)

--- a/tests/integration/prerelease.bats
+++ b/tests/integration/prerelease.bats
@@ -79,8 +79,8 @@ teardown() {
     avakas_wrapper show "$REPO"
 
     # Will only show on errors
-    echo "'${output}' does not match the expected '^1.2.3\-1.${ALMOST}[0-9]{2}'"
-    [[ "$output" =~ "^1.2.3\-1.${ALMOST}[0-9]{2}" ]]    
+    echo "'${output}' does not match the expected '^1.2.3\-1.${ALMOST}[0-9]{2}$'"
+    [[ "$output" =~ ^1.2.3\-1.${ALMOST}[0-9]{2}$ ]]    
 }
 
 @test "set a prerelease w/date and git build" {

--- a/tests/integration/prerelease.bats
+++ b/tests/integration/prerelease.bats
@@ -169,11 +169,27 @@ teardown() {
     unset GITHUB_RUN_NUMBER
 }
 
-@test "increment prerelease multiple times w/ prefix" {
+@test "minimal increment prerelease multiple times w/ prefix" {
     avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix beta
     avakas_wrapper show "$REPO"
     [ "$output" == "0.0.1-beta.1" ]
     avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix beta
     avakas_wrapper show "$REPO"
     [ "$output" == "0.0.1-beta.2" ]
+}
+
+
+@test "increment prerelease multiple times w/ prefix, changing prefix" {
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix beta
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-beta.1" ]
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix beta
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-beta.2" ]
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix beta
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-beta.3"]
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix rc
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-rc.1"]
 }

--- a/tests/integration/prerelease.bats
+++ b/tests/integration/prerelease.bats
@@ -66,11 +66,21 @@ teardown() {
     unset GITHUB_RUN_NUMBER
 }
 
-@test "set a prerelease w/date" {
+@test "bump a prerelease w/date" {
     avakas_wrapper bump "$REPO" patch --prerelease --prerelease-date
     ALMOST="$(TZ='UTC' date "+%Y%m%d%H%M")"
     MATCH="$(rev <<< "$output" | cut -c 3- | rev)"
     grep -v "0.0.1\-1.${ALMOST}[0-9]{2}" <<< "$output"
+}
+
+@test "set a prerelease w/date" {
+    avakas_wrapper set "$REPO" 1.2.3 --prerelease --prerelease-date
+    ALMOST="$(TZ='UTC' date "+%Y%m%d%H%M")"
+    avakas_wrapper show "$REPO"
+
+    # Will only show on errors
+    echo "'${output}' does not match the expected '^1.2.3\-1.${ALMOST}[0-9]{2}'"
+    [[ "$output" =~ "^1.2.3\-1.${ALMOST}[0-9]{2}" ]]    
 }
 
 @test "set a prerelease w/date and git build" {

--- a/tests/integration/prerelease.bats
+++ b/tests/integration/prerelease.bats
@@ -168,3 +168,12 @@ teardown() {
     unset GITHUB_RUN_ID
     unset GITHUB_RUN_NUMBER
 }
+
+@test "increment prerelease multiple times w/ prefix" {
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix beta
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-beta.1" ]
+    avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix beta
+    avakas_wrapper show "$REPO"
+    [ "$output" == "0.0.1-beta.2" ]
+}

--- a/tests/integration/prerelease.bats
+++ b/tests/integration/prerelease.bats
@@ -188,8 +188,8 @@ teardown() {
     [ "$output" == "0.0.1-beta.2" ]
     avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix beta
     avakas_wrapper show "$REPO"
-    [ "$output" == "0.0.1-beta.3"]
+    [ "$output" == "0.0.1-beta.3" ]
     avakas_wrapper bump "$REPO" patch --prerelease --prerelease-prefix rc
     avakas_wrapper show "$REPO"
-    [ "$output" == "0.0.1-rc.1"]
+    [ "$output" == "0.0.1-rc.1" ]
 }


### PR DESCRIPTION
fixes #63, by integrating the prerelease version bump into the main version bump

As a follow up to this, I should add specific tests for prerelease work to flavors which implement their own versions of any part of the bump, just to be certain of consistency

All tests are passing. I think it may be ready, but given that it's a larger code change, I want to get a good review of it before making this a real PR