### PR TITLE
Demonstrate Issue #72

### DIFF
--- a/avakas/cli.py
+++ b/avakas/cli.py
@@ -67,7 +67,7 @@ def ci_build_meta():
     return meta
 
 
-def cli_show_version(**_kwargs):
+def cli_show_version(**kwargs):
     """Show the current flavour specific version for a project."""
     project = detect_project_flavor(**kwargs)
     if not project.read():

--- a/avakas/cli.py
+++ b/avakas/cli.py
@@ -69,7 +69,9 @@ def ci_build_meta():
 
 def cli_show_version(**_kwargs):
     """Show the current flavour specific version for a project."""
-
+    project = detect_project_flavor(**kwargs)
+    if not project.read():
+        raise AvakasError('Unable to extract current version')
     # Throw a wrench in the works
     print('foo')
 

--- a/avakas/cli.py
+++ b/avakas/cli.py
@@ -69,15 +69,16 @@ def ci_build_meta():
 
 def cli_show_version(**kwargs):
     """Show the current flavour specific version for a project."""
-    project = detect_project_flavor(**kwargs)
-    if not project.read():
-        raise AvakasError('Unable to extract current version')
 
-    print("%s" % str(project.version))
+    # Throw a wrench in the works
+    print('foo')
 
 
 def cli_bump_version(**kwargs):
     """Bump the flavour specific version for a project."""
+    print('foo')
+    sys.exit(0)
+
     project = detect_project_flavor(**kwargs)
     if not project.read():
         raise AvakasError('Unable to extract current version')
@@ -96,6 +97,9 @@ def cli_bump_version(**kwargs):
 
 def cli_set_version(**kwargs):
     """Manually set the flavour specific version for a project."""
+
+    print('foo')
+    sys.exit(0)
     version = kwargs['version'][0]
     project = detect_project_flavor(**kwargs)
 

--- a/avakas/cli.py
+++ b/avakas/cli.py
@@ -67,7 +67,7 @@ def ci_build_meta():
     return meta
 
 
-def cli_show_version(**kwargs):
+def cli_show_version(**_kwargs):
     """Show the current flavour specific version for a project."""
 
     # Throw a wrench in the works


### PR DESCRIPTION
This isn't meant to be ever made a full PR

This PR demonstrates the issues with the prerelease tests for when prerelease date is used, from issue #72 . Though the CLI functions only output 'foo' in this PR, these tests pass.

Note the successful tests in the checks [here](https://github.com/otakup0pe/avakas/pull/73/checks?check_run_id=1717494146#step:5:303), these test _should not_ pass